### PR TITLE
#43 Realized

### DIFF
--- a/src/spider/app/pipelines.py
+++ b/src/spider/app/pipelines.py
@@ -1,10 +1,10 @@
 import os
+from typing import List
 import pymongo
-import logging
+from pymongo import UpdateOne
 
 
 class SpiderMainPipeline:
-        
     def __init__(self, mongo_uri, mongo_db):
         self.mongo_uri = mongo_uri
         self.mongo_db = mongo_db
@@ -12,35 +12,32 @@ class SpiderMainPipeline:
     @classmethod
     def from_crawler(cls, crawler):
         return cls(
-            mongo_uri=os.environ.get('MONGO_URI'),
-            mongo_db=os.environ.get('MONGO_DB'),
+            mongo_uri=os.environ.get('MONGO_URI', 'mongodb://crwl:Crawly97@localhost:27017'),
+            mongo_db=os.environ.get('MONGO_DB', "crawly"),
         )
 
     def open_spider(self, spider):
         self.client = pymongo.MongoClient(self.mongo_uri)
         self.db = self.client[self.mongo_db]
-        try: 
-            spider.last_item_hash = self.db[spider.template_uuid].find({}, {"__hash":1}, sort=[("_id", pymongo.ASCENDING)]).limit(1)[0].get('__hash')
-        except IndexError:
-            pass
         self.item_collection = spider.template_uuid
 
     def close_spider(self, spider):
         items = spider.item_tree.get_items()
         indexes = spider.item_tree.get_indexes()
         schema_uuid = spider.schema_uuid
+        mongo_operations = []
         for index, item in zip(indexes, items):
-            if index != spider.last_item_hash:
-                item['__processed'] = False
-                item['__hash'] = index
-                item['__schema_uuid'] = schema_uuid
-                self.insert_item(item)
-            else:
-                break
+            item['__processed'] = False
+            item['__hash'] = index
+            item['__schema_uuid'] = schema_uuid
+            mongo_operations.append(
+                UpdateOne({"__hash": index},{ "$set": item },upsert=True)
+                )
+        self.bulk_upsert(mongo_operations)
         self.client.close()
         
-    def insert_item(self, item):
-        self.db[self.item_collection].insert_one(item)
+    def bulk_upsert(self, operations: List):
+        res = self.db[self.item_collection].bulk_write(operations, ordered=False)
 
     def process_item(self, item, spider):
         return item


### PR DESCRIPTION
Rewrite spider pipeline for saving scraped items to MongoDB. Changed to bulk write for efficiency, made all queries with upsert without checking for duplicate items. If particular scraped item is already present in DB then update this item if something has changed. The uniqueness is checked by __hash field in item.
#43 Realized